### PR TITLE
Change readme to Pulsar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# YAML language support in Atom
+# YAML language support in Pulsar
 [![macOS Build Status](https://travis-ci.org/atom/language-yaml.svg?branch=master)](https://travis-ci.org/atom/language-yaml)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/eaa4ql7kipgphc2n/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/language-yaml/branch/master)
 [![Dependency Status](https://david-dm.org/atom/language-yaml.svg)](https://david-dm.org/atom/language-yaml)
+(These builds are all for the upstream atom/language.yaml)
 
-Adds syntax highlighting to YAML files in Atom.
+Adds syntax highlighting to YAML files in Pulsar.
 
 Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate) from the [YAML TextMate bundle](https://github.com/textmate/yaml.tmbundle).
 


### PR DESCRIPTION
This PR changes the names in the readme to Pulsar. I also added message about CI builds being for upstream (If someone knows more about this than me feel free to edit)
